### PR TITLE
add last_full_capacity to battery status

### DIFF
--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -54,6 +54,7 @@ volume master {
 }
 
 battery 1 {
+	last_full_capacity = true
         format = "<span background='#a3be8c'>  %status %percentage </span>"
         format_down = "No Battery"
         status_chr = "Charging"


### PR DESCRIPTION
according this https://i3wm.org/i3status/manpage.html#_battery, we need add last_full_capacity to resolved miss full percentage battery